### PR TITLE
Listen for connections on all interfaces & provide alternate tunnel

### DIFF
--- a/qjupyter.sh
+++ b/qjupyter.sh
@@ -20,6 +20,8 @@ else
   echo "If you cannot access http://$HOSTNAME:$port then you will need an SSH tunnel"
   echo "Your SSH tunnel command on your desktop should look like the following"
   echo "  ssh -L 9999:localhost:8888 $USER@\$GATEWAY ssh -L 8888:localhost:$port $HOSTNAME"
+  echo "or"
+  echo "  ssh -L 9999:\$HOSTNAME:\$port $USER@\$GATEWAY"   
   echo
   echo "  This job was submitted from $PBS_O_HOST and it may be able to serve as the \$GATEWAY node"
   echo
@@ -27,5 +29,5 @@ else
   echo
   echo "To terminate this notebook session press ctrl-C twice."
   echo
-  jupyter notebook --no-browser --port=$port
+  jupyter notebook --no-browser --port=$port --ip='*'
 fi

--- a/qjupyter.sh
+++ b/qjupyter.sh
@@ -21,7 +21,7 @@ else
   echo "Your SSH tunnel command on your desktop should look like the following"
   echo "  ssh -L 9999:localhost:8888 $USER@\$GATEWAY ssh -L 8888:localhost:$port $HOSTNAME"
   echo "or"
-  echo "  ssh -L 9999:\$HOSTNAME:\$port $USER@\$GATEWAY"   
+  echo "  ssh -L 9999:$HOSTNAME:$port $USER@\$GATEWAY"   
   echo
   echo "  This job was submitted from $PBS_O_HOST and it may be able to serve as the \$GATEWAY node"
   echo


### PR DESCRIPTION
The two changes here open the listening up to more interfaces than the  http://localhost:port and provide an alternate tunnel command that ends at the GATEWAY and attempts to contact the the server through a more public external interface.

See http://jupyter-notebook.readthedocs.io/en/latest/public_server.html for details on the interface option.